### PR TITLE
Use module-alias for path resolving after compilation

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -12,4 +12,7 @@ module.exports = {
     '**/*.(test|spec).(ts|js)',
   ],
   testEnvironment: 'node',
+  moduleNameMapper: {
+    '@app/(.*)$': '<rootDir>/src/$1',
+  }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -4651,6 +4651,11 @@
         "minimist": "0.0.8"
       }
     },
+    "module-alias": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/module-alias/-/module-alias-2.0.6.tgz",
+      "integrity": "sha1-q7LPoHAU9QNRStUGHG8D15tZGIk="
+    },
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -7,13 +7,13 @@
     "start": "npm run build && npm run serve",
     "build": "npm run build-ts",
     "test": "jest --forceExit --coverage --verbose --runInBand",
-    "lint": "tslint -p .",
+    "lint": "tslint --format stylish --project .",
     "serve": "node dist/server.js",
     "build-ts": "tsc",
     "watch-ts": "tsc -w",
     "watch-node": "nodemon dist/server.js",
     "watch-test": "jest --watch",
-    "watch": "npm run build-ts && concurrently -k -p \"[{name}]\" -n \"TypeScript,Node\" -c \"blue.bold,green.bold\" \"npm run watch-ts\" \"npm run watch-node\" "
+    "watch": "concurrently -k -p \"[{name}]\" -n \"TypeScript,Node\" -c \"blue.bold,green.bold\" \"npm run watch-ts\" \"npm run watch-node\" "
   },
   "author": "",
   "license": "MIT",
@@ -27,6 +27,7 @@
     "express": "^4.16.2",
     "express-session": "^1.15.6",
     "lodash": "^4.17.5",
+    "module-alias": "^2.0.6",
     "passport": "^0.4.0",
     "passport-local": "^1.0.0"
   },
@@ -52,5 +53,8 @@
     "tslint": "^5.9.1",
     "tslint-config-airbnb": "^5.6.0",
     "typescript": "^2.7.2"
+  },
+  "_moduleAliases": {
+    "@app": "./dist"
   }
 }

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -1,6 +1,7 @@
 import { Router } from 'express';
-import { sampleController } from './modules/sample';
-import { homeController } from './modules/home';
+import { sampleController } from '@app/modules/sample';
+import { homeController } from '@app/modules/home';
+
 const router = Router();
 
 router.use('/', homeController);

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,7 +1,8 @@
+import 'module-alias/register';
 import 'dotenv/config';
 import errorhandler from 'errorhandler';
 import debug from 'debug';
-import app from './app';
+import app from '@app/app';
 
 if (process.env.NODE_ENV === 'development') {
   app.use(errorhandler());

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,14 +2,16 @@
   "compilerOptions": {
     "module": "commonjs",
     "target": "es6",
-    "esModuleInterop": true,
     "moduleResolution": "node",
+    "esModuleInterop": true,
     "noImplicitAny": true,
     "sourceMap": true,
     "removeComments": true,
-    "noUnusedLocals": true,
     "outDir": "dist",
-    "baseUrl": "."
+    "baseUrl": ".",
+    "paths": {
+      "@app/*": ["./src/*"]
+    }
   },
   "include": [
     "src/**/*"


### PR DESCRIPTION
In order to allow path aliases use `module-alias` package.